### PR TITLE
Add meta options

### DIFF
--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -100,7 +100,7 @@ export default class VerifiableCredentialStore {
    * @param {object} credential
    * @param {object} meta
    */
-  async insert({credential, meta}) {
+  async insert({credential, meta = meta || {}}) {
     const {invocationSigner} = this;
     meta.issuer = this._getIssuer({credential});
     const doc = await this.edv.insert({

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -71,7 +71,7 @@ export default class VerifiableCredentialStore {
       return {
         content,
         meta
-      }
+      };
     });
   }
 

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -50,9 +50,9 @@ export default class VerifiableCredentialStore {
     const equals = {};
     if(type) {
       if(Array.isArray(type)) {
-        // FIXME: needs testing
-        const query = type.map(type => ({'content.type': type}));
-        equals['content.type'] = query;
+        // FIXME: querying by an array of types does not work and will need
+        // to be fixed in order to work with compound indexes.
+        throw new Error('"type" as array is not implemented.');
       } else {
         equals['content.type'] = type;
       }

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -10,7 +10,11 @@ export default class VerifiableCredentialStore {
   constructor({edv, invocationSigner}) {
     this.edv = edv;
     this.invocationSigner = invocationSigner;
-    this.edv.ensureIndex({attribute: ['meta.issuer', 'content.type']});
+    this.edv.ensureIndex({attribute: [
+      'meta.issuer',
+      'meta.listDisplay',
+      'content.type'
+    ]});
     this.edv.ensureIndex({attribute: 'content.id', unique: true});
   }
 
@@ -38,25 +42,37 @@ export default class VerifiableCredentialStore {
    *
    * @param {string} [type]
    * @param {string} [issuer]
+   * @param {boolean} [listDisplay]
    *
    * @return {Promise<Array>} List of matching VCs
    */
-  async find({type, issuer}) {
-    const equals = [];
+  async find({type, issuer, listDisplay}) {
+    const equals = {};
     if(type) {
       if(Array.isArray(type)) {
+        // FIXME: needs testing
         const query = type.map(type => ({'content.type': type}));
-        equals.push(...query);
+        equals['content.type'] = query;
       } else {
-        equals.push({'content.type': type});
+        equals['content.type'] = type;
       }
     }
     if(issuer) {
-      equals.push({'meta.issuer': issuer});
+      equals['meta.issuer'] = issuer;
     }
+    if(listDisplay) {
+      equals['meta.listDisplay'] = listDisplay;
+    }
+    console.log('equals', equals);
     const {invocationSigner} = this;
     const {documents: docs} = await this.edv.find({equals, invocationSigner});
-    return docs.map(({content}) => content);
+    console.log('docs', docs);
+    return docs.map(({content, meta}) => {
+      return {
+        content,
+        meta
+      }
+    });
   }
 
   /**
@@ -85,13 +101,15 @@ export default class VerifiableCredentialStore {
    * Stores a verifiable credential in remote private storage
    *
    * @param {Object} credential
+   * @param {Object} meta
    */
-  async insert({credential}) {
+  async insert({credential, meta}) {
     const {invocationSigner} = this;
-    const issuer = this._getIssuer({credential});
+    console.log('meta', meta);
+    meta.issuer = this._getIssuer({credential});
     const doc = await this.edv.insert({
       doc: {
-        meta: {issuer},
+        meta,
         content: credential
       },
       invocationSigner

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -12,7 +12,7 @@ export default class VerifiableCredentialStore {
     this.invocationSigner = invocationSigner;
     this.edv.ensureIndex({attribute: [
       'meta.issuer',
-      'meta.listDisplay',
+      'meta.displayable',
       'content.type'
     ]});
     this.edv.ensureIndex({attribute: 'content.id', unique: true});
@@ -42,11 +42,11 @@ export default class VerifiableCredentialStore {
    *
    * @param {string} [type]
    * @param {string} [issuer]
-   * @param {boolean} [listDisplay]
+   * @param {boolean} [displayable]
    *
    * @return {Promise<Array>} List of matching VCs
    */
-  async find({type, issuer, listDisplay}) {
+  async find({type, issuer, displayable}) {
     const equals = {};
     if(type) {
       if(Array.isArray(type)) {
@@ -59,8 +59,8 @@ export default class VerifiableCredentialStore {
     if(issuer) {
       equals['meta.issuer'] = issuer;
     }
-    if(listDisplay) {
-      equals['meta.listDisplay'] = listDisplay;
+    if(displayable) {
+      equals['meta.displayable'] = displayable;
     }
     const {invocationSigner} = this;
     const {documents: docs} = await this.edv.find({equals, invocationSigner});

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -50,8 +50,7 @@ export default class VerifiableCredentialStore {
     const equals = {};
     if(type) {
       if(Array.isArray(type)) {
-        // FIXME: querying by an array of types does not work and will need
-        // to be fixed in order to work with compound indexes.
+        // needs to be implemented on the edv-client side first
         throw new Error('"type" as array is not implemented.');
       } else {
         equals['content.type'] = type;
@@ -98,8 +97,8 @@ export default class VerifiableCredentialStore {
   /**
    * Stores a verifiable credential in remote private storage
    *
-   * @param {Object} credential
-   * @param {Object} meta
+   * @param {object} credential
+   * @param {object} meta
    */
   async insert({credential, meta}) {
     const {invocationSigner} = this;

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -63,10 +63,8 @@ export default class VerifiableCredentialStore {
     if(listDisplay) {
       equals['meta.listDisplay'] = listDisplay;
     }
-    console.log('equals', equals);
     const {invocationSigner} = this;
     const {documents: docs} = await this.edv.find({equals, invocationSigner});
-    console.log('docs', docs);
     return docs.map(({content, meta}) => {
       return {
         content,
@@ -105,7 +103,6 @@ export default class VerifiableCredentialStore {
    */
   async insert({credential, meta}) {
     const {invocationSigner} = this;
-    console.log('meta', meta);
     meta.issuer = this._getIssuer({credential});
     const doc = await this.edv.insert({
       doc: {

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -100,7 +100,7 @@ export default class VerifiableCredentialStore {
    * @param {object} credential
    * @param {object} meta
    */
-  async insert({credential, meta = meta || {}}) {
+  async insert({credential, meta = {}}) {
     const {invocationSigner} = this;
     meta.issuer = this._getIssuer({credential});
     const doc = await this.edv.insert({


### PR DESCRIPTION
### This is a
- [ ] fix
- [x] feature
- [ ] other

### This PR will:
- Add additional meta options.
- Add listDisplay as a new index to specify if a credential is displayed or not.
- Add ability for meta to be passed into `insert()`.

### This was tested:
This was tested in the wallet using the new bundle credentials.

- [ ] I have updated the CHANGELOG and used semantic versioning.