### PR TITLE
Add support for storing VCs without an `id` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-web-vc-store ChangeLog
 
+## 7.4.0 - 2022-08-xx
+
+### Added
+- Add support for credentials without an `id` property. A new index
+  on a new credential record property, `meta.id`, will be created and
+  the `meta.id` property will be populated for all newly inserted or
+  updated credentials. The `meta.id` property will be set to the
+  `credential.id` value if present and a new UUID URN if not.
+
 ## 7.3.2 - 2022-06-03
 
 ### Fixed

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -5,6 +5,7 @@ import * as assert from './assert.js';
 import canonicalize from 'canonicalize';
 import pAll from 'p-all';
 import {LruCache} from '@digitalbazaar/lru-memoize';
+import {v4 as uuid} from 'uuid';
 
 // `10` is chosen as the concurrency value because it is the lowest power of
 // ten that is an acceptable number of concurrent web requests when pipelining
@@ -60,6 +61,12 @@ export class VerifiableCredentialStore {
 
     // index to find by VC ID
     edvClient.ensureIndex({attribute: 'content.id', unique: true});
+    // index to find by VC ID *or* auto-generated ID; covers case that
+    // VC does not have an `id`; this is backwards-compatible with
+    // `content.id` and requires that VCs without unique IDs have globally
+    // unambiguous IDs (e.g., UUIDs) generated for them to avoid conflicts
+    edvClient.ensureIndex({attribute: 'meta.id', unique: true});
+
     // index to find by issuer
     edvClient.ensureIndex({
       attribute: ['meta.issuer', 'meta.displayable', 'content.type']
@@ -254,13 +261,12 @@ export class VerifiableCredentialStore {
     assert.object(meta, 'meta');
     const now = Date.now();
     meta = {created: now, updated: now, ...meta};
+    // ensure `meta.id` is set
+    if(!meta.id) {
+      meta.id = credential.id ?? `urn:uuid:${uuid()}`;
+    }
     if(bundleContents !== undefined) {
       assert.bundleContents(bundleContents, 'bundleContents');
-      // a VC without an ID cannot be a bundle
-      if(!credential.id) {
-        throw new Error(
-          '"credential.id" must be a string to define a bundle.');
-      }
       if(bundleContents.length > 0) {
         // VC is a bundle
         meta.bundle = true;
@@ -273,8 +279,7 @@ export class VerifiableCredentialStore {
     if(addBundleContentsFirst) {
       // add any bundle contents first by request
       if(bundleContents && bundleContents.length > 0) {
-        await this._addBundleContents(
-          {bundleId: credential.id, bundleContents});
+        await this._addBundleContents({bundleId: meta.id, bundleContents});
       }
     }
 
@@ -286,8 +291,7 @@ export class VerifiableCredentialStore {
     if(!addBundleContentsFirst) {
       // now add any bundle contents
       if(bundleContents && bundleContents.length > 0) {
-        await this._addBundleContents(
-          {bundleId: credential.id, bundleContents});
+        await this._addBundleContents({bundleId: meta.id, bundleContents});
       }
     }
 
@@ -301,8 +305,10 @@ export class VerifiableCredentialStore {
    *
    * @param {object} options - The options to use.
    * @param {object} options.credential - The credential to upsert; it will be
-   *   set as the `content` of the EDV document; "credential.id" must be a
-   *   string.
+   *   set as the `content` of the EDV document; either `credential.id` or
+   *   `meta.id` must be a string (for credentials without an `id` property) to
+   *   perform an update; if neither are set, then the credential will always
+   *   be treated as new and inserted.
    * @param {object} [options.meta={}] - Custom meta data to set; the `issuer`
    *   field will be auto-populated if not set in the custom `meta`.
    * @param {Function} [options.mutator] - A function that takes the options
@@ -340,10 +346,11 @@ export class VerifiableCredentialStore {
     }
     const now = Date.now();
     meta = {created: now, updated: now, ...meta};
-    // `id` required to use `upsert`
-    if(typeof credential.id !== 'string') {
-      throw new TypeError('"credential.id" must be a string.');
+    // ensure `meta.id` is set
+    if(!meta.id) {
+      meta.id = credential.id ?? `urn:uuid:${uuid()}`;
     }
+
     if(bundleContents !== undefined) {
       assert.bundleContents(bundleContents, 'bundleContents');
       if(bundleContents.length > 0) {
@@ -358,8 +365,7 @@ export class VerifiableCredentialStore {
     if(addBundleContentsFirst) {
       // add any bundle contents first by request
       if(bundleContents && bundleContents.length > 0) {
-        await this._addBundleContents(
-          {bundleId: credential.id, bundleContents});
+        await this._addBundleContents({bundleId: meta.id, bundleContents});
       }
     }
 
@@ -381,9 +387,9 @@ export class VerifiableCredentialStore {
     // update again
     let doc;
     let isNew = true;
-    if(this._credentialCache.cache.has(credential.id)) {
+    if(this._credentialCache.cache.has(meta.id)) {
       try {
-        doc = await this._credentialCache.cache.get(credential.id);
+        doc = await this._credentialCache.cache.get(meta.id);
         isNew = false;
       } catch(e) {}
     }
@@ -426,7 +432,7 @@ export class VerifiableCredentialStore {
         // like we predicted...
         try {
           // try to get a fresh copy of the doc
-          doc = await this.get({id: credential.id});
+          doc = await this.get({id: meta.id});
           // got it, so doc is not new; loop to try to update it
           isNew = false;
           continue;
@@ -438,8 +444,9 @@ export class VerifiableCredentialStore {
           }
 
           // doc doesn't exist and we were trying to insert it as new, which
-          // means some field other than `credential.id` is in conflict and
-          // therefore we can't add it, so throw the original duplicate error
+          // means some field other than `credential.id`/`meta.id` is in
+          // conflict and therefore we can't add it, so throw the original
+          // duplicate error
           if(isNew) {
             throw updateError;
           }
@@ -456,14 +463,13 @@ export class VerifiableCredentialStore {
     if(!result) {
       // retries exhausted and no result
       throw new Error(
-        `Failed to upsert credential "${credential.id}"; too many retries.`);
+        `Failed to upsert credential "${meta.id}"; too many retries.`);
     }
 
     if(!addBundleContentsFirst) {
       // now add any bundle contents
       if(bundleContents && bundleContents.length > 0) {
-        await this._addBundleContents(
-          {bundleId: credential.id, bundleContents});
+        await this._addBundleContents({bundleId: meta.id, bundleContents});
       }
     }
 
@@ -560,9 +566,9 @@ export class VerifiableCredentialStore {
       }
 
       if(!doc) {
-        // fetch doc by `content.id`
+        // fetch doc by `content.id` or `meta.id`
         ({documents: [doc]} = await this.edvClient.find({
-          equals: {'content.id': id}
+          equals: [{'content.id': id}, {'meta.id': id}]
         }));
       }
 
@@ -853,7 +859,7 @@ export class VerifiableCredentialStore {
 
   async _getUncached({id}) {
     const {documents: [doc]} = await this.edvClient.find({
-      equals: {'content.id': id}
+      equals: [{'content.id': id}, {'meta.id': id}]
     });
     if(!doc) {
       const err = new Error('Verifiable Credential not found.');
@@ -890,15 +896,16 @@ export function defaultMutator({doc, credential, meta}) {
   // find the same doc again by `content.id` if the VC was still deleted during
   // the retry
   if(canonicalize(doc.content) !== canonicalize(credential)) {
+    const credentialId = credential.id ?? meta.id;
     console.error(
-      `Credential ID "${credential.id}" is a duplicate and the previously ` +
+      `Credential ID "${credentialId}" is a duplicate and the previously ` +
       'stored credential does not match.', {
         old: doc.content,
         new: credential
       });
     /*const error = new Error('Duplicate credential.');
     error.name = 'DuplicateError';
-    error.credentialId = credential.id;
+    error.credentialId = credentialId;
     throw error;*/
   }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@digitalbazaar/lru-memoize": "^2.2.0",
     "canonicalize": "^1.0.8",
-    "p-all": "^3.0.0"
+    "p-all": "^3.0.0",
+    "uuid": "^8.3.2"
   },
   "keywords": [
     "Verifiable",


### PR DESCRIPTION
This still needs additional testing in top-level applications to check for corner cases / erroneous behavior.