### PR TITLE
Spread meta on upsert overwrite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-web-vc-store ChangeLog
 
+## 8.0.1 - 2023-09-xx
+
+### Fixed
+- Ensure `meta` is spread when overwriting without mutator
+  on upsert.
+
 ## 8.0.0 - 2022-08-19
 
 ### Changed

--- a/lib/VerifiableCredentialStore.js
+++ b/lib/VerifiableCredentialStore.js
@@ -410,7 +410,7 @@ export class VerifiableCredentialStore {
           // no custom mutator so just overwrite directly; preserve `created`
           // date
           const created = doc?.meta?.created ?? meta?.created;
-          doc.meta = {meta, created};
+          doc.meta = {...meta, created};
           doc.content = credential;
         }
       }

--- a/test/web/credentials.js
+++ b/test/web/credentials.js
@@ -24,6 +24,8 @@ const alumniCredential = {
   "issuer": "https://example.edu/issuers/565049",
   // when the credential was issued
   "issuanceDate": "2010-01-01T19:73:24Z",
+  // when the credential expires
+  "expirationDate": "2022-01-01T19:23:24Z",
   // claims about the subjects of the credential
   "credentialSubject": {
     // identifier for the only subject of the credential
@@ -43,6 +45,12 @@ const alumniCredential = {
   }
 };
 
+const refreshedCredential = {
+  ...alumniCredential,
+  "expirationDate": "2027-06-14T18:37:12Z"
+};
+
 export default {
-  alumniCredential
+  alumniCredential,
+  refreshedCredential
 };


### PR DESCRIPTION
Resolves an issue where `meta` was being nested when upserting with no mutator (bypassing default).

![image](https://github.com/digitalbazaar/bedrock-web-vc-store/assets/5930765/9f0f6f4b-ad61-4571-b06e-59528ec7fb57)

Dropping in results of tests since its not running automatically on this PR

```
➜  npm run test

> bedrock-web-vc-store-test@0.0.1-0 test
> node --preserve-symlinks test.js test --framework karma

Running Test Frameworks...

Running tests via Karma...

START:
Webpack bundling...
[BABEL] Note: The code generator has deoptimised the styling of /home/tolson/dev/db/bedrock-web-vc-store/test/node_modules/sinon/pkg/sinon-esm.js as it exceeds the max of 500KB.
asset commons.js 2.59 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 8.68 KiB [emitted] (name: runtime)
asset 10-VerifiableCredentialStore.3340236278.js 1.06 KiB [emitted] (name: 10-VerifiableCredentialStore.3340236278)
asset credentials.2038119879.js 1.02 KiB [emitted] (name: credentials.2038119879)
asset mockStorage.1301316775.js 1.02 KiB [emitted] (name: mockStorage.1301316775)
asset mockServer.652814594.js 1.02 KiB [emitted] (name: mockServer.652814594)
asset mockHmac.2883840506.js 1.02 KiB [emitted] (name: mockHmac.2883840506)
asset query.2676883712.js 1.01 KiB [emitted] (name: query.2676883712)
asset mock.3109153567.js 1.01 KiB [emitted] (name: mock.3109153567)
webpack 5.88.2 compiled successfully in 3635 ms
[2023-09-13T13:46:02.551] [INFO] karma-server - Karma v6.4.2 server started at https://localhost:9876/
[2023-09-13T13:46:02.551] [INFO] launcher - Launching browsers Chrome_without_security with concurrency unlimited
[2023-09-13T13:46:02.554] [INFO] launcher - Starting browser ChromeHeadless
[2023-09-13T13:46:02.811] [INFO] Chrome Headless 117.0.5938.62 (Linux x86_64) - Connected on socket 32Gd-K0E3SPPwcxvAAAB with id 81201033
  VerifiableCredentialStore
    ✔ fails to get with a misconfigured EdvClient
    ✔ should insert a credential
    ✔ should upsert a credential
    ✔ should overwrite an existing credential
ERROR: 'Credential ID "http://example.edu/credentials/1872" is a duplicate and the previously stored credential does not match.', Object{old: Object{@context: [..., ..., ...], id: 'http://example.edu/credentials/1872', type: [..., ...], issuer: 'https://example.edu/issuers/565049', issuanceDate: '2010-01-01T19:73:24Z', expirationDate: '2022-01-01T19:23:24Z', credentialSubject: Object{id: ..., alumniOf: ...}, proof: Object{type: ..., created: ..., proofPurpose: ..., proofValue: ..., verificationMethod: ...}}, new: Object{@context: [..., ..., ...], id: 'http://example.edu/credentials/1872', type: [..., ...], issuer: 'https://example.edu/issuers/565049', issuanceDate: '2010-01-01T19:73:24Z', expirationDate: '2027-06-14T18:37:12Z', credentialSubject: Object{id: ..., alumniOf: ...}, proof: Object{type: ..., created: ..., proofPurpose: ..., proofValue: ..., verificationMethod: ...}}}
    ✔ should not overwrite an existing credential with default mutator
    ✔ should get a credential
    ✔ should find a credential using a string for type
    ✔ should find a credential using an array for type
    ✔ should fail to find a credential for a non-existent type
    ✔ should find a credential for a given issuer
    ✔ should fail to find a credential for a non-existent issuer
    ✔ should not find credential when querying for an AlumniCredential with an issuer different from the issuer on the credential
    ✔ should throw error if "id" of a trustedIssuer is undefined
    ✔ should find credential when querying for an AlumniCredential with a matching issuer
    ✔ should find credential when querying for an AlumniCredential with any issuer
    ✔ should delete an existing credential
    ✔ should fail to delete a non-existent credential
    bundles with defaults
      ✔ should fail to insert non-array bundle
      ✔ should fail to insert non-array of objects bundle
      ✔ should insert a bundle
      ✔ should fail to upsert non-array bundle
      ✔ should fail to upsert non-array of objects bundle
      ✔ should upsert a bundle
      ✔ should upsert a bundle that mutates an existing VC
      ✔ should get a bundle
      ✔ should delete a bundle
      ✔ should delete a bundle w/ preserve independent contents
      ✔ should delete a bundle w/ preserve pre-existing contents
      ✔ should delete a bundle w/ preserve other bundled contents
      ✔ should fail to delete a member of an existing bundle
      ✔ should force delete a member of an existing bundle
      ✔ should fail to delete a credential w/o its bundle
      ✔ should force delete a credential w/o its bundle
      ✔ should upsert a deep bundle
      ✔ should delete a deep bundle
      ✔ should fail to delete a deep member of an existing bundle
      ✔ should force delete a deep member of an existing bundle
    bundles with addBundleContentsFirst=false
      ✔ should fail to insert non-array bundle
      ✔ should fail to insert non-array of objects bundle
      ✔ should insert a bundle
      ✔ should fail to upsert non-array bundle
      ✔ should fail to upsert non-array of objects bundle
      ✔ should upsert a bundle
      ✔ should upsert a bundle that mutates an existing VC
      ✔ should get a bundle
      ✔ should delete a bundle
      ✔ should delete a bundle w/ preserve independent contents
      ✔ should delete a bundle w/ preserve pre-existing contents
      ✔ should delete a bundle w/ preserve other bundled contents
      ✔ should fail to delete a member of an existing bundle
      ✔ should force delete a member of an existing bundle
      ✔ should fail to delete a credential w/o its bundle
      ✔ should force delete a credential w/o its bundle
      ✔ should upsert a deep bundle
      ✔ should delete a deep bundle
      ✔ should fail to delete a deep member of an existing bundle
      ✔ should force delete a deep member of an existing bundle
    bundles with addBundleContentsFirst=true
      ✔ should fail to insert non-array bundle
      ✔ should fail to insert non-array of objects bundle
      ✔ should insert a bundle
      ✔ should fail to upsert non-array bundle
      ✔ should fail to upsert non-array of objects bundle
      ✔ should upsert a bundle
      ✔ should upsert a bundle that mutates an existing VC
      ✔ should get a bundle
      ✔ should delete a bundle
      ✔ should delete a bundle w/ preserve independent contents
      ✔ should delete a bundle w/ preserve pre-existing contents
      ✔ should delete a bundle w/ preserve other bundled contents
      ✔ should fail to delete a member of an existing bundle
      ✔ should force delete a member of an existing bundle
      ✔ should fail to delete a credential w/o its bundle
      ✔ should force delete a credential w/o its bundle
      ✔ should upsert a deep bundle
      ✔ should delete a deep bundle
      ✔ should fail to delete a deep member of an existing bundle
      ✔ should force delete a deep member of an existing bundle

Finished in 1.499 secs / 1.438 secs @ 13:46:04 GMT-0400 (Eastern Daylight Time)

SUMMARY:
✔ 77 tests completed
All tests passed.
```